### PR TITLE
Add a catch for using different header files depending on linux kernel version

### DIFF
--- a/3.x_and_later/serial_core.c
+++ b/3.x_and_later/serial_core.c
@@ -36,7 +36,14 @@
 #include <linux/serial_core.h>
 #include <linux/delay.h>
 #include <linux/mutex.h>
+
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,11,0)
+#include <linux/signal.h>
+#else
 #include <linux/sched/signal.h>
+#endif
 
 #include <asm/irq.h>
 #include <asm/uaccess.h>


### PR DESCRIPTION
Adding a catch to use the correct signal header file based on the linux kernel version.
Newer linux kernels now use linux/sched/signal.h where it use to be linux/signal.h

This patch allows the code to be compiled on both linux versions and find the correct location without compile error.